### PR TITLE
feat(serialization): Add ability to deserialize models

### DIFF
--- a/IGDB.Tests/Serialization.cs
+++ b/IGDB.Tests/Serialization.cs
@@ -1,0 +1,74 @@
+using System;
+using System.Collections.Generic;
+using IGDB.Models;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using Xunit;
+
+namespace IGDB.Tests
+{
+  public class SerializationTests
+  {
+    [Fact]
+    public void IdentityConverter_Should_Serialize_and_Deserialize_Id()
+    {
+      var game = new Game();
+      game.ParentGame = new IdentityOrValue<Game>(3);
+
+      var serialized = JsonConvert.SerializeObject(game, IGDB.Client.DefaultJsonSerializerSettings);
+      var deserialized = JsonConvert.DeserializeObject<Game>(serialized, IGDB.Client.DefaultJsonSerializerSettings);
+
+      Assert.NotNull(deserialized.ParentGame);
+      Assert.NotNull(deserialized.ParentGame.Id);
+      Assert.Equal(3, deserialized.ParentGame.Id.Value);
+    }
+
+    [Fact]
+    public void IdentityConverter_Should_Serialize_and_Deserialize_Value()
+    {
+      var game = new Game();
+      game.ParentGame = new IdentityOrValue<Game>(new Game() { Name = "Test" });
+
+      var serialized = JsonConvert.SerializeObject(game, IGDB.Client.DefaultJsonSerializerSettings);
+      var deserialized = JsonConvert.DeserializeObject<Game>(serialized, IGDB.Client.DefaultJsonSerializerSettings);
+
+      Assert.NotNull(deserialized.ParentGame);
+      Assert.NotNull(deserialized.ParentGame.Value.Name);
+      Assert.Equal("Test", deserialized.ParentGame.Value.Name);
+    }
+
+    [Fact]
+    public void IdentityConverter_Should_Serialize_and_Deserialize_Ids()
+    {
+      var game = new Game();
+      game.Genres = new IdentitiesOrValues<Genre>(new long[] { 0, 1, 2, 3 });
+
+      var serialized = JsonConvert.SerializeObject(game, IGDB.Client.DefaultJsonSerializerSettings);
+      var deserialized = JsonConvert.DeserializeObject<Game>(serialized, IGDB.Client.DefaultJsonSerializerSettings);
+
+      Assert.NotNull(deserialized.Genres);
+      Assert.NotNull(deserialized.Genres.Ids);
+      Assert.Contains(0, deserialized.Genres.Ids);
+      Assert.Contains(3, deserialized.Genres.Ids);
+    }
+
+    [Fact]
+    public void IdentityConverter_Should_Serialize_and_Deserialize_Values()
+    {
+      var game = new Game();
+      var genres = new Genre[] {
+        new Genre() { Id = 1 },
+        new Genre() { Id = 3 }
+      };
+      game.Genres = new IdentitiesOrValues<Genre>(genres);
+
+      var serialized = JsonConvert.SerializeObject(game, IGDB.Client.DefaultJsonSerializerSettings);
+      var deserialized = JsonConvert.DeserializeObject<Game>(serialized, IGDB.Client.DefaultJsonSerializerSettings);
+
+      Assert.NotNull(deserialized.Genres);
+      Assert.NotNull(deserialized.Genres.Values);
+      Assert.Equal(1, deserialized.Genres.Values[0].Id.Value);
+      Assert.Equal(3, deserialized.Genres.Values[1].Id.Value);
+    }
+  }
+}

--- a/IGDB.Tests/Serialization.cs
+++ b/IGDB.Tests/Serialization.cs
@@ -70,5 +70,18 @@ namespace IGDB.Tests
       Assert.Equal(1, deserialized.Genres.Values[0].Id.Value);
       Assert.Equal(3, deserialized.Genres.Values[1].Id.Value);
     }
+
+    [Fact]
+    public void UnixTimestampConverter_Should_Serialize_And_Deserialize_Unix_Time() {
+      var time = DateTimeOffset.Now;
+      var game = new Game() {
+        CreatedAt = time
+      };
+
+      var serialized = JsonConvert.SerializeObject(game, IGDB.Client.DefaultJsonSerializerSettings);
+      var deserialized = JsonConvert.DeserializeObject<Game>(serialized, IGDB.Client.DefaultJsonSerializerSettings);
+
+      Assert.Equal(time.ToUnixTimeSeconds(), deserialized.CreatedAt.Value.ToUnixTimeSeconds());
+    }
   }
 }

--- a/IGDB/IGDBApi.cs
+++ b/IGDB/IGDBApi.cs
@@ -46,6 +46,18 @@ namespace IGDB
   public static class Client
   {
 
+    public static JsonSerializerSettings DefaultJsonSerializerSettings = new JsonSerializerSettings()
+    {
+      Converters = new List<JsonConverter>() {
+          new IdentityConverter(),
+          new UnixTimestampConverter()
+        },
+      ContractResolver = new DefaultContractResolver()
+      {
+        NamingStrategy = new SnakeCaseNamingStrategy()
+      }
+    };
+
     /// <summary>
     /// Create a default IGDB API client with specified API key
     /// </summary>
@@ -65,17 +77,7 @@ namespace IGDB
     /// <returns></returns>
     public static IGDBApi Create(string apiKey, RestClient client)
     {
-      client.JsonSerializerSettings = new JsonSerializerSettings()
-      {
-        Converters = new List<JsonConverter>() {
-          new IdentityConverter(),
-          new UnixTimestampConverter()
-        },
-        ContractResolver = new DefaultContractResolver()
-        {
-          NamingStrategy = new SnakeCaseNamingStrategy()
-        }
-      };
+      client.JsonSerializerSettings = DefaultJsonSerializerSettings;
 
       var api = client.For<IGDBApi>();
       api.ApiKey = apiKey;

--- a/IGDB/Serialization/UnixTimestampConverter.cs
+++ b/IGDB/Serialization/UnixTimestampConverter.cs
@@ -4,35 +4,44 @@ using Newtonsoft.Json.Linq;
 
 namespace IGDB
 {
-    public class UnixTimestampConverter : JsonConverter
+  public class UnixTimestampConverter : JsonConverter
+  {
+    public override bool CanConvert(Type objectType)
     {
-        public override bool CanConvert(Type objectType)
-        {
-            return objectType.IsAssignableFrom(typeof(DateTimeOffset));
-        }
-
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
-        {
-            var defaultDateTime = default(DateTimeOffset);
-
-            if (reader.TokenType != JsonToken.Null)
-            {
-                if (reader.TokenType == JsonToken.Integer)
-                {
-                    var rawValue = reader.Value.ToString();
-                    long parsedUnixTimestamp;
-                    if (long.TryParse(rawValue, out parsedUnixTimestamp))
-                    {
-                        return DateTimeOffset.FromUnixTimeSeconds(parsedUnixTimestamp);
-                    }
-                }
-            }
-            return defaultDateTime;
-        }
-
-        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
-        {
-            throw new InvalidOperationException();
-        }
+      return objectType.IsAssignableFrom(typeof(DateTimeOffset));
     }
+
+    public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+    {
+      var defaultDateTime = default(DateTimeOffset);
+
+      if (reader.TokenType != JsonToken.Null)
+      {
+        if (reader.TokenType == JsonToken.Integer)
+        {
+          var rawValue = reader.Value.ToString();
+          long parsedUnixTimestamp;
+          if (long.TryParse(rawValue, out parsedUnixTimestamp))
+          {
+            return DateTimeOffset.FromUnixTimeSeconds(parsedUnixTimestamp);
+          }
+        }
+      }
+      return defaultDateTime;
+    }
+
+    public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+    {
+      var offset = value as DateTimeOffset?;
+
+      if (offset.HasValue)
+      {
+        JToken.FromObject(offset.Value.ToUnixTimeSeconds()).WriteTo(writer);
+      }
+      else
+      {
+        JToken.FromObject(value).WriteTo(writer);
+      }
+    }
+  }
 }

--- a/IGDB/Serialization/UnixTimestampConverter.cs
+++ b/IGDB/Serialization/UnixTimestampConverter.cs
@@ -4,7 +4,7 @@ using Newtonsoft.Json.Linq;
 
 namespace IGDB
 {
-    internal class UnixTimestampConverter : JsonConverter
+    public class UnixTimestampConverter : JsonConverter
     {
         public override bool CanConvert(Type objectType)
         {


### PR DESCRIPTION
## Changes

- Expose static `IGDB.Client.DefaultJsonSerializerSettings` for easier usage in consumer code
- Expose publicly `IdentityConverter` and `UnixTimestampConverter`
- Add implementation to `IdentityConverter` to write JSON appropriately
- Add implementation to `UnixTimestampConverter` to write JSON appropriately

## Usage

You can utilize the public `IGDB.Client.DefaultJsonSerializerSettings` whenever serializing or deserializing model objects in your own code.

```c#
var game = new Game();
game.ParentGame = new IdentityOrValue<Game>(new Game() { Name = "Test" });

var serialized = JsonConvert.SerializeObject(game, IGDB.Client.DefaultJsonSerializerSettings);
var deserialized = JsonConvert.DeserializeObject<Game>(serialized, IGDB.Client.DefaultJsonSerializerSettings);
```