### PR TITLE
feat: Switch Id fields to Int64, add IIdentifier interface

### DIFF
--- a/IGDB/Models/Achievement.cs
+++ b/IGDB/Models/Achievement.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace IGDB.Models
 {
-  public class Achievement : ITimestamps
+  public class Achievement : ITimestamps, IIdentifier
   {
     public IdentityOrValue<AchievementIcon> AchievementIcon { get; set; }
     public AchievementCategory Category { get; set; }
@@ -10,7 +10,7 @@ namespace IGDB.Models
     public string Description { get; set; }
     public string ExternalId { get; set; }
     public IdentityOrValue<Game> Game { get; set; }
-    public int? Id { get; set; }
+    public long? Id { get; set; }
     public AchievementLanguage Language { get; set; }
     public string Name { get; set; }
     public double? OwnersPercentage { get; set; }

--- a/IGDB/Models/AchievementIcon.cs
+++ b/IGDB/Models/AchievementIcon.cs
@@ -1,11 +1,11 @@
 namespace IGDB.Models
 {
-  public class AchievementIcon
+  public class AchievementIcon : IIdentifier
   {
     public bool? AlphaChannel { get; set; }
     public bool? Animated { get; set; }
     public int? Height { get; set; }
-    public int? Id { get; set; }
+    public long? Id { get; set; }
     public string ImageId { get; set; }
     public string Url { get; set; }
     public int? Width { get; set; }

--- a/IGDB/Models/AgeRating.cs
+++ b/IGDB/Models/AgeRating.cs
@@ -1,10 +1,10 @@
 namespace IGDB.Models
 {
-    public class AgeRating
+    public class AgeRating : IIdentifier
     {
         public AgeRatingCategory? Category { get; set; }
         public IdentitiesOrValues<AgeRatingContentDescription> ContentDescriptions { get; set; }
-        public int? Id { get; set; }
+        public long? Id { get; set; }
         public AgeRatingTitle? Rating { get; set; }
         public string RatingCoverUrl { get; set; }
         public string Synopsis { get; set; }

--- a/IGDB/Models/AgeRatingContentDescription.cs
+++ b/IGDB/Models/AgeRatingContentDescription.cs
@@ -1,10 +1,10 @@
 namespace IGDB.Models
 {
-  public class AgeRatingContentDescription
+  public class AgeRatingContentDescription : IIdentifier
   {
     public AgeRatingContentDescriptionCategory? Category { get; set; }
     public string Description { get; set; }
-    public int? Id { get; set; }
+    public long? Id { get; set; }
   }
 
   public enum AgeRatingContentDescriptionCategory

--- a/IGDB/Models/AlternativeName.cs
+++ b/IGDB/Models/AlternativeName.cs
@@ -1,10 +1,10 @@
 namespace IGDB.Models
 {
-    public class AlternativeName
+    public class AlternativeName : IIdentifier
     {
         public string Comment { get; set; }
         public IdentityOrValue<Game> Game { get; set; }
-        public int? Id { get; set; }
+        public long? Id { get; set; }
         public string Name { get; set; }
     }
 }

--- a/IGDB/Models/Artwork.cs
+++ b/IGDB/Models/Artwork.cs
@@ -2,13 +2,13 @@ using Newtonsoft.Json;
 
 namespace IGDB.Models
 {
-    public class Artwork
+    public class Artwork : IIdentifier
     {
         public bool? AlphaChannel { get; set; }
         public bool? Animated { get; set; }
         public IdentityOrValue<Game> Game { get; set; }
         public int? Height { get; set; }
-        public int? Id { get; set; }
+        public long? Id { get; set; }
         public string ImageId { get; set; }
         public string Url { get; set; }
         public int? Width { get; set; }

--- a/IGDB/Models/Character.cs
+++ b/IGDB/Models/Character.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace IGDB.Models
 {
-  public class Character : ITimestamps
+  public class Character : ITimestamps, IIdentifier
   {
     public string[] Akas { get; set; }
     public string CountryName { get; set; }
@@ -10,7 +10,7 @@ namespace IGDB.Models
     public string Description { get; set; }
     public IdentitiesOrValues<Game> Games { get; set; }
     public Gender? Gender { get; set; }
-    public int? Id { get; set; }
+    public long? Id { get; set; }
     public IdentityOrValue<CharacterMugShot> MugShot { get; set; }
     public string Name { get; set; }
     public IdentitiesOrValues<People> People { get; set; }

--- a/IGDB/Models/CharacterMugShot.cs
+++ b/IGDB/Models/CharacterMugShot.cs
@@ -1,11 +1,11 @@
 namespace IGDB.Models
 {
-  public class CharacterMugShot
+  public class CharacterMugShot : IIdentifier
   {
     public bool? AlphaChannel { get; set; }
     public bool? Animated { get; set; }
     public int? Height { get; set; }
-    public int? Id { get; set; }
+    public long? Id { get; set; }
     public string ImageId { get; set; }
     public string Url { get; set; }
     public int? Width { get; set; }

--- a/IGDB/Models/Collection.cs
+++ b/IGDB/Models/Collection.cs
@@ -3,12 +3,12 @@ using Newtonsoft.Json;
 
 namespace IGDB.Models
 {
-  public class Collection : ITimestamps
+  public class Collection : ITimestamps, IIdentifier
   {
     public DateTimeOffset? CreatedAt { get; set; }
 
     public IdentitiesOrValues<Game> Games { get; set; }
-    public int? Id { get; set; }
+    public long? Id { get; set; }
 
     public string Name { get; set; }
 

--- a/IGDB/Models/Company.cs
+++ b/IGDB/Models/Company.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace IGDB.Models
 {
-  public class Company : ITimestamps
+  public class Company : ITimestamps, IIdentifier
   {
     public DateTimeOffset? ChangeDate { get; set; }
     public ChangeDateCategory ChangeDateCategory { get; set; }
@@ -18,7 +18,7 @@ namespace IGDB.Models
     public string Description { get; set; }
 
     public IdentitiesOrValues<Game> Developed { get; set; }
-    public int? Id { get; set; }
+    public long? Id { get; set; }
 
     public IdentityOrValue<CompanyLogo> Logo { get; set; }
 

--- a/IGDB/Models/CompanyLogo.cs
+++ b/IGDB/Models/CompanyLogo.cs
@@ -1,11 +1,11 @@
-namespace IGDB
+namespace IGDB.Models
 {
-  public class CompanyLogo
+  public class CompanyLogo : IIdentifier
   {
     public bool? AlphaChannel { get; set; }
     public bool? Animated { get; set; }
     public int? Height { get; set; }
-    public int? Id { get; set; }
+    public long? Id { get; set; }
     public string ImageId { get; set; }
     public string Url { get; set; }
     public int? Width { get; set; }

--- a/IGDB/Models/CompanyWebsite.cs
+++ b/IGDB/Models/CompanyWebsite.cs
@@ -1,9 +1,9 @@
 namespace IGDB.Models
 {
-  public class CompanyWebsite
+  public class CompanyWebsite : IIdentifier
   {
     public WebsiteCategory? Category { get; set; }
-    public int? Id { get; set; }
+    public long? Id { get; set; }
     public bool? Trusted { get; set; }
     public string Url { get; set; }
   }

--- a/IGDB/Models/Cover.cs
+++ b/IGDB/Models/Cover.cs
@@ -2,12 +2,12 @@ using Newtonsoft.Json;
 
 namespace IGDB.Models
 {
-  public class Cover
+  public class Cover : IIdentifier
   {
     public bool? AlphaChannel { get; set; }
     public bool? Animated { get; set; }
     public IdentityOrValue<Game> Game { get; set; }
-    public int? Id { get; set; }
+    public long? Id { get; set; }
     public int? Height { get; set; }
     public string ImageId { get; set; }
     public string Url { get; set; }

--- a/IGDB/Models/ExternalGame.cs
+++ b/IGDB/Models/ExternalGame.cs
@@ -2,14 +2,14 @@ using System;
 
 namespace IGDB.Models
 {
-  public class ExternalGame : ITimestamps
+  public class ExternalGame : ITimestamps, IIdentifier
   {
     public ExternalCategory? Category { get; set; }
 
     public DateTimeOffset? CreatedAt { get; set; }
 
     public IdentityOrValue<Game> Game { get; set; }
-    public int? Id { get; set; }
+    public long? Id { get; set; }
 
     public string Name { get; set; }
 

--- a/IGDB/Models/Feed.cs
+++ b/IGDB/Models/Feed.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace IGDB.Models
 {
-  public class Feed : ITimestamps
+  public class Feed : ITimestamps, IIdentifier
   {
     public FeedCategory? Category { get; set; }
     public string Content { get; set; }
@@ -10,7 +10,7 @@ namespace IGDB.Models
     public int? FeedLikesCount { get; set; }
     public IdentityOrValue<GameVideo> FeedVideo { get; set; }
     public IdentitiesOrValues<Game> Games { get; set; }
-    public int? Id { get; set; }
+    public long? Id { get; set; }
     public string Meta { get; set; }
     public DateTimeOffset? PublishedAt { get; set; }
     public IdentityOrValue<Pulse> Pulse { get; set; }

--- a/IGDB/Models/FeedFollow.cs
+++ b/IGDB/Models/FeedFollow.cs
@@ -2,10 +2,10 @@ using System;
 
 namespace IGDB.Models
 {
-  public class FeedFollow : ITimestamps
+  public class FeedFollow : ITimestamps, IIdentifier
   {
     public DateTimeOffset? CreatedAt { get; set; }
-    public int? Id { get; set; }
+    public long? Id { get; set; }
     public FeedFollowCategory? Feed { get; set; }
     public DateTimeOffset? PublishedAt { get; set; }
     public DateTimeOffset? UpdatedAt { get; set; }

--- a/IGDB/Models/Follow.cs
+++ b/IGDB/Models/Follow.cs
@@ -1,8 +1,8 @@
 namespace IGDB.Models
 {
-    public class Follow
+    public class Follow : IIdentifier
     {
-        public int? Id { get; set; }
+        public long? Id { get; set; }
         public IdentityOrValue<Game> Game { get; set; }
         public IdentityOrValue<User> User { get; set; }
     }

--- a/IGDB/Models/Franchise.cs
+++ b/IGDB/Models/Franchise.cs
@@ -2,11 +2,11 @@ using System;
 
 namespace IGDB.Models
 {
-  public class Franchise : ITimestamps
+  public class Franchise : ITimestamps, IIdentifier
   {
     public DateTimeOffset? CreatedAt { get; set; }
     public DateTimeOffset? UpdatedAt { get; set; }
-    public int? Id { get; set; }
+    public long? Id { get; set; }
     public IdentitiesOrValues<Game> Games { get; set; }
     public string Name { get; set; }
     public string Slug { get; set; }

--- a/IGDB/Models/Game.cs
+++ b/IGDB/Models/Game.cs
@@ -3,7 +3,7 @@ using Newtonsoft.Json;
 
 namespace IGDB.Models
 {
-  public class Game : ITimestamps
+  public class Game : ITimestamps, IIdentifier
   {
     public IdentitiesOrValues<AgeRating> AgeRatings { get; set; }
 
@@ -47,7 +47,7 @@ namespace IGDB.Models
 
     public int? Hypes { get; set; }
 
-    public int? Id { get; set; }
+    public long? Id { get; set; }
 
     public IdentitiesOrValues<InvolvedCompany> InvolvedCompanies { get; set; }
 

--- a/IGDB/Models/GameEngine.cs
+++ b/IGDB/Models/GameEngine.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace IGDB.Models
 {
-  public class GameEngine : ITimestamps
+  public class GameEngine : ITimestamps, IIdentifier
   {
     public IdentitiesOrValues<Company> Companies { get; set; }
 
@@ -10,7 +10,7 @@ namespace IGDB.Models
 
     public string Description { get; set; }
     public IdentityOrValue<GameEngineLogo> Logo { get; set; }
-    public int? Id { get; set; }
+    public long? Id { get; set; }
 
     public string Name { get; set; }
 

--- a/IGDB/Models/GameEngineLogo.cs
+++ b/IGDB/Models/GameEngineLogo.cs
@@ -1,11 +1,11 @@
 namespace IGDB.Models
 {
-  public class GameEngineLogo
+  public class GameEngineLogo : IIdentifier
   {
     public bool? AlphaChannel { get; set; }
     public bool? Animated { get; set; }
     public int? Height { get; set; }
-    public int? Id { get; set; }
+    public long? Id { get; set; }
     public string ImageId { get; set; }
     public string Url { get; set; }
     public int? Width { get; set; }

--- a/IGDB/Models/GameMode.cs
+++ b/IGDB/Models/GameMode.cs
@@ -2,10 +2,10 @@ using System;
 
 namespace IGDB.Models
 {
-  public class GameMode : ITimestamps
+  public class GameMode : ITimestamps, IIdentifier
   {
     public DateTimeOffset? CreatedAt { get; set; }
-    public int? Id { get; set; }
+    public long? Id { get; set; }
     public string Name { get; set; }
     public string Slug { get; set; }
     public DateTimeOffset? UpdatedAt { get; set; }

--- a/IGDB/Models/GameVersion.cs
+++ b/IGDB/Models/GameVersion.cs
@@ -2,13 +2,13 @@ using System;
 
 namespace IGDB.Models
 {
-  public class GameVersion : ITimestamps
+  public class GameVersion : ITimestamps, IIdentifier
   {
     public DateTimeOffset? CreatedAt { get; set; }
     public IdentitiesOrValues<GameVersionFeature> Features { get; set; }
     public IdentityOrValue<Game> Game { get; set; }
     public IdentitiesOrValues<Game> Games { get; set; }
-    public int? Id { get; set; }
+    public long? Id { get; set; }
     public DateTimeOffset? UpdatedAt { get; set; }
     public string Url { get; set; }
   }

--- a/IGDB/Models/GameVersionFeature.cs
+++ b/IGDB/Models/GameVersionFeature.cs
@@ -1,10 +1,10 @@
 namespace IGDB.Models
 {
-  public class GameVersionFeature
+  public class GameVersionFeature : IIdentifier
   {
     public GameVersionFeatureCategory Category { get; set; }
     public string Description { get; set; }
-    public int? Id { get; set; }
+    public long? Id { get; set; }
     public int? Position { get; set; }
     public string Title { get; set; }
     public IdentitiesOrValues<GameVersionFeatureValue> Values { get; set; }

--- a/IGDB/Models/GameVersionFeatureValue.cs
+++ b/IGDB/Models/GameVersionFeatureValue.cs
@@ -1,10 +1,10 @@
 namespace IGDB.Models
 {
-  public class GameVersionFeatureValue
+  public class GameVersionFeatureValue : IIdentifier
   {
     public IdentityOrValue<Game> Game { get; set; }
     public IdentityOrValue<GameVersionFeature> Feature { get; set; }
-    public int? Id { get; set; }
+    public long? Id { get; set; }
     public IncludedFeature? IncludedFeature { get; set; }
     public string Note { get; set; }
   }

--- a/IGDB/Models/GameVideo.cs
+++ b/IGDB/Models/GameVideo.cs
@@ -1,9 +1,9 @@
 namespace IGDB.Models
 {
-  public class GameVideo
+  public class GameVideo : IIdentifier
   {
     public IdentityOrValue<Game> Game { get; set; }
-    public int? Id { get; set; }
+    public long? Id { get; set; }
     public string Name { get; set; }
     public string VideoId { get; set; }
   }

--- a/IGDB/Models/Genre.cs
+++ b/IGDB/Models/Genre.cs
@@ -3,12 +3,12 @@ using Newtonsoft.Json;
 
 namespace IGDB.Models
 {
-    public class Genre : ITimestamps
+    public class Genre : ITimestamps, IIdentifier
     {
         public DateTimeOffset? CreatedAt { get; set; }
 
         public DateTimeOffset? UpdatedAt { get; set; }
-        public int? Id { get; set; }
+        public long? Id { get; set; }
 
         public string Name { get; set; }
 

--- a/IGDB/Models/IIdentifier.cs
+++ b/IGDB/Models/IIdentifier.cs
@@ -1,0 +1,7 @@
+namespace IGDB.Models
+{
+  public interface IIdentifier
+  {
+    long? Id { get; set; }
+  }
+}

--- a/IGDB/Models/InvolvedCompany.cs
+++ b/IGDB/Models/InvolvedCompany.cs
@@ -2,13 +2,13 @@ using System;
 
 namespace IGDB.Models
 {
-  public class InvolvedCompany : ITimestamps
+  public class InvolvedCompany : ITimestamps, IIdentifier
   {
     public IdentityOrValue<Company> Company { get; set; }
     public DateTimeOffset? CreatedAt { get; set; }
     public bool? Developer { get; set; }
     public IdentityOrValue<Game> Game { get; set; }
-    public int? Id { get; set; }
+    public long? Id { get; set; }
     public bool? Porting { get; set; }
     public bool? Publisher { get; set; }
     public bool? Supporting { get; set; }

--- a/IGDB/Models/Keyword.cs
+++ b/IGDB/Models/Keyword.cs
@@ -2,10 +2,10 @@ using System;
 
 namespace IGDB.Models
 {
-  public class Keyword : ITimestamps
+  public class Keyword : ITimestamps, IIdentifier
   {
     public DateTimeOffset? CreatedAt { get; set; }
-    public int? Id { get; set; }
+    public long? Id { get; set; }
     public string Name { get; set; }
     public string Slug { get; set; }
     public DateTimeOffset? UpdatedAt { get; set; }

--- a/IGDB/Models/List.cs
+++ b/IGDB/Models/List.cs
@@ -2,21 +2,22 @@ using System;
 
 namespace IGDB.Models
 {
-    public class List : ITimestamps
-    {
-        public DateTimeOffset? CreatedAt { get; set; }
-        public string Description { get; set; }
-        public int? EntriesCount { get; set; }
-        public IdentitiesOrValues<ListEntry> ListEntries { get; set; }
-        public int[] ListTags { get; set; }
-        public IdentitiesOrValues<Game> ListedGames { get; set; }
-        public string Name{get;set;}
-        public bool? Numbering{get;set;}
-        public bool? Private { get; set; }
-        public IdentitiesOrValues<List> SimilarLists { get; set; }
-        public string Slug { get; set; }
-        public DateTimeOffset? UpdatedAt { get; set; }
-        public string Url { get; set; }
-        public IdentityOrValue<User> User { get; set; }
-    }
+  public class List : ITimestamps, IIdentifier
+  {
+    public DateTimeOffset? CreatedAt { get; set; }
+    public string Description { get; set; }
+    public int? EntriesCount { get; set; }
+    public long? Id { get; set; }
+    public IdentitiesOrValues<ListEntry> ListEntries { get; set; }
+    public int[] ListTags { get; set; }
+    public IdentitiesOrValues<Game> ListedGames { get; set; }
+    public string Name { get; set; }
+    public bool? Numbering { get; set; }
+    public bool? Private { get; set; }
+    public IdentitiesOrValues<List> SimilarLists { get; set; }
+    public string Slug { get; set; }
+    public DateTimeOffset? UpdatedAt { get; set; }
+    public string Url { get; set; }
+    public IdentityOrValue<User> User { get; set; }
+  }
 }

--- a/IGDB/Models/Me.cs
+++ b/IGDB/Models/Me.cs
@@ -1,8 +1,8 @@
 namespace IGDB.Models
 {
-    public class Me
+    public class Me : IIdentifier
     {
-        public int? Id { get; set; }
+        public long? Id { get; set; }
         public string Username { get; set; }
         public string Slug { get; set; }
         public string Presentation { get; set; }

--- a/IGDB/Models/MultiplayerMode.cs
+++ b/IGDB/Models/MultiplayerMode.cs
@@ -2,14 +2,14 @@ using Newtonsoft.Json;
 
 namespace IGDB.Models
 {
-  public class MultiplayerMode
+  public class MultiplayerMode : IIdentifier
   {
     [JsonProperty("campaigncoop")]
     public bool? CampaignCoop { get; set; }
     [JsonProperty("dropin")]
     public bool? DropIn { get; set; }
     public IdentityOrValue<Game> Game { get; set; }
-    public int? Id { get; set; }
+    public long? Id { get; set; }
     [JsonProperty("lancoop")]
     public bool? LanCoop { get; set; }
     [JsonProperty("offlinecoop")]

--- a/IGDB/Models/Page.cs
+++ b/IGDB/Models/Page.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace IGDB.Models
 {
-  public class Page : ITimestamps
+  public class Page : ITimestamps, IIdentifier
   {
     public IdentityOrValue<PageBackground> Background { get; set; }
     public string Battlenet { get; set; }
@@ -14,7 +14,7 @@ namespace IGDB.Models
     public string Description { get; set; }
     public IdentityOrValue<Feed> Feed { get; set; }
     public IdentityOrValue<Game> Game { get; set; }
-    public int? Id { get; set; }
+    public long? Id { get; set; }
     public string Name { get; set; }
     public string Origin { get; set; }
     public int? PageFollowsCount { get; set; }

--- a/IGDB/Models/Platform.cs
+++ b/IGDB/Models/Platform.cs
@@ -2,14 +2,14 @@ using System;
 
 namespace IGDB.Models
 {
-  public class Platform : ITimestamps
+  public class Platform : ITimestamps, IIdentifier
   {
     public string Abbreviation { get; set; }
     public string AlternativeName { get; set; }
     public PlatformCategory Category { get; set; }
     public DateTimeOffset? CreatedAt { get; set; }
     public int? Generation { get; set; }
-    public int? Id { get; set; }
+    public long? Id { get; set; }
     public string Name { get; set; }
     public IdentityOrValue<PlatformLogo> PlatformLogo { get; set; }
     public IdentityOrValue<ProductFamily> ProductFamily { get; set; }

--- a/IGDB/Models/PlatformLogo.cs
+++ b/IGDB/Models/PlatformLogo.cs
@@ -1,11 +1,11 @@
-namespace IGDB
+namespace IGDB.Models
 {
-  public class PlatformLogo
+  public class PlatformLogo : IIdentifier
   {
      public bool? AlphaChannel { get; set; }
     public bool? Animated { get; set; }
     public int? Height { get; set; }
-    public int? Id { get; set; }
+    public long? Id { get; set; }
     public string ImageId { get; set; }
     public string Url { get; set; }
     public int? Width { get; set; }

--- a/IGDB/Models/PlatformVersion.cs
+++ b/IGDB/Models/PlatformVersion.cs
@@ -2,14 +2,14 @@ using Newtonsoft.Json;
 
 namespace IGDB.Models
 {
-  public class PlatformVersion
+  public class PlatformVersion : IIdentifier
   {
     public IdentitiesOrValues<PlatformVersionCompany> Companies { get; set; }
     public string Connectivity { get; set; }
     [JsonProperty("cpu")]
     public string CPU { get; set; }
     public string Graphics { get; set; }
-    public int? Id { get; set; }
+    public long? Id { get; set; }
     public IdentityOrValue<PlatformVersionCompany> MainManufacturer { get; set; }
     public string Media { get; set; }
     public string Memory { get; set; }

--- a/IGDB/Models/PlatformVersionCompany.cs
+++ b/IGDB/Models/PlatformVersionCompany.cs
@@ -1,11 +1,11 @@
 namespace IGDB.Models
 {
-  public class PlatformVersionCompany
+  public class PlatformVersionCompany : IIdentifier
   {
     public string Comment { get; set; }
     public IdentityOrValue<Company> Company { get; set; }
     public bool? Developer { get; set; }
-    public int? Id { get; set; }
+    public long? Id { get; set; }
     public bool? Manufacturer { get; set; }
   }
 }

--- a/IGDB/Models/PlatformVersionReleaseDate.cs
+++ b/IGDB/Models/PlatformVersionReleaseDate.cs
@@ -3,13 +3,13 @@ using Newtonsoft.Json;
 
 namespace IGDB.Models
 {
-  public class PlatformVersionReleaseDate : ITimestamps
+  public class PlatformVersionReleaseDate : ITimestamps, IIdentifier
   {
     public ReleaseDateCategory? Category { get; set; }
     public DateTimeOffset? CreatedAt { get; set; }
     public DateTimeOffset? Date { get; set; }
     public string Human { get; set; }
-    public int? Id { get; set; }
+    public long? Id { get; set; }
     [JsonProperty("m")]
     public int? Month { get; set; }
     public IdentityOrValue<PlatformVersion> PlatformVersion { get; set; }

--- a/IGDB/Models/PlatformWebsite.cs
+++ b/IGDB/Models/PlatformWebsite.cs
@@ -1,9 +1,9 @@
 namespace IGDB.Models
 {
-  public class PlatformWebsite
+  public class PlatformWebsite : IIdentifier
   {
     public WebsiteCategory? Category { get; set; }
-    public int? Id { get; set; }
+    public long? Id { get; set; }
     public bool? Trusted { get; set; }
     public string Url { get; set; }
   }

--- a/IGDB/Models/PlayerPerspective.cs
+++ b/IGDB/Models/PlayerPerspective.cs
@@ -2,10 +2,10 @@ using System;
 
 namespace IGDB.Models
 {
-  public class PlayerPerspective : ITimestamps
+  public class PlayerPerspective : ITimestamps, IIdentifier
   {
     public DateTimeOffset? CreatedAt { get; set; }
-    public int? Id { get; set; }
+    public long? Id { get; set; }
     public string Name { get; set; }
     public string Slug { get; set; }
     public DateTimeOffset? UpdatedAt { get; set; }

--- a/IGDB/Models/ProductFamily.cs
+++ b/IGDB/Models/ProductFamily.cs
@@ -1,8 +1,8 @@
 namespace IGDB.Models
 {
-  public class ProductFamily
+  public class ProductFamily : IIdentifier
   {
-    public int? Id { get; set; }
+    public long? Id { get; set; }
     public string Name { get; set; }
     public string Slug { get; set; }
   }

--- a/IGDB/Models/Pulse.cs
+++ b/IGDB/Models/Pulse.cs
@@ -2,11 +2,11 @@ using System;
 
 namespace IGDB.Models
 {
-  public class Pulse : ITimestamps
+  public class Pulse : ITimestamps, IIdentifier
   {
     public string Author { get; set; }
     public DateTimeOffset? CreatedAt { get; set; }
-    public int? Id { get; set; }
+    public long? Id { get; set; }
     public string Image { get; set; }
     public DateTimeOffset? PublishedAt { get; set; }
     public IdentityOrValue<PulseSource> PulseSource { get; set; }

--- a/IGDB/Models/PulseGroup.cs
+++ b/IGDB/Models/PulseGroup.cs
@@ -2,11 +2,11 @@ using System;
 
 namespace IGDB.Models
 {
-  public class PulseGroup : ITimestamps
+  public class PulseGroup : ITimestamps, IIdentifier
   {
     public DateTimeOffset? CreatedAt { get; set; }
     public IdentityOrValue<Game> Game { get; set; }
-    public int? Id { get; set; }
+    public long? Id { get; set; }
     public string Name { get; set; }
     public DateTimeOffset? PublishedAt { get; set; }
     public IdentitiesOrValues<Pulse> Pulses { get; set; }

--- a/IGDB/Models/PulseSource.cs
+++ b/IGDB/Models/PulseSource.cs
@@ -1,9 +1,9 @@
 namespace IGDB.Models
 {
-  public class PulseSource
+  public class PulseSource : IIdentifier
   {
     public IdentityOrValue<Game> Game { get; set; }
-    public int? Id { get; set; }
+    public long? Id { get; set; }
     public string Name { get; set; }
     public IdentityOrValue<Page> Page { get; set; }
   }

--- a/IGDB/Models/PulseUrl.cs
+++ b/IGDB/Models/PulseUrl.cs
@@ -1,8 +1,8 @@
 namespace IGDB.Models
 {
-  public class PulseUrl
+  public class PulseUrl : IIdentifier
   {
-    public int? Id { get; set; }
+    public long? Id { get; set; }
     public bool? Trusted { get; set; }
     public string Url { get; set; }
   }

--- a/IGDB/Models/ReleaseDate.cs
+++ b/IGDB/Models/ReleaseDate.cs
@@ -3,13 +3,13 @@ using Newtonsoft.Json;
 
 namespace IGDB.Models
 {
-  public class ReleaseDate : ITimestamps
+  public class ReleaseDate : ITimestamps, IIdentifier
   {
     public ReleaseDateCategory? Category { get; set; }
     public DateTimeOffset? CreatedAt { get; set; }
     public DateTimeOffset? Date { get; set; }
     public IdentityOrValue<Game> Game { get; set; }
-    public int? Id { get; set; }
+    public long? Id { get; set; }
     public string Human { get; set; }
     [JsonProperty("m")]
     public int? Month { get; set; }

--- a/IGDB/Models/Screenshot.cs
+++ b/IGDB/Models/Screenshot.cs
@@ -1,12 +1,12 @@
 namespace IGDB.Models
 {
-  public class Screenshot
+  public class Screenshot : IIdentifier
   {
     public bool? AlphaChannel { get; set; }
     public bool? Animated { get; set; }
     public IdentityOrValue<Game> Game { get; set; }
     public int? Height { get; set; }
-    public int? Id { get; set; }
+    public long? Id { get; set; }
     public string ImageId { get; set; }
     public string Url { get; set; }
     public int? Width { get; set; }

--- a/IGDB/Models/Theme.cs
+++ b/IGDB/Models/Theme.cs
@@ -2,10 +2,10 @@ using System;
 
 namespace IGDB.Models
 {
-  public class Theme : ITimestamps
+  public class Theme : ITimestamps, IIdentifier
   {
     public DateTimeOffset? CreatedAt { get; set; }
-    public int? Id { get; set; }
+    public long? Id { get; set; }
     public string Name { get; set; }
     public string Slug { get; set; }
     public DateTimeOffset? UpdatedAt { get; set; }

--- a/IGDB/Models/TimeToBeat.cs
+++ b/IGDB/Models/TimeToBeat.cs
@@ -1,9 +1,9 @@
 namespace IGDB.Models
 {
-  public class TimeToBeat
+  public class TimeToBeat : IIdentifier
   {
     public int? Completely { get; set; }
-    public int? Id { get; set; }
+    public long? Id { get; set; }
     public IdentityOrValue<Game> Game { get; set; }
     public int? Hastly { get; set; }
     public int? Normally { get; set; }

--- a/IGDB/Models/Title.cs
+++ b/IGDB/Models/Title.cs
@@ -2,12 +2,12 @@ using System;
 
 namespace IGDB.Models
 {
-  public class Title : ITimestamps
+  public class Title : ITimestamps, IIdentifier
   {
     public DateTimeOffset? CreatedAt { get; set; }
     public string Description { get; set; }
     public IdentitiesOrValues<Game> Games { get; set; }
-    public int? Id { get; set; }
+    public long? Id { get; set; }
     public string Name { get; set; }
     public string Slug { get; set; }
     public DateTimeOffset? UpdatedAt { get; set; }

--- a/IGDB/Models/User.cs
+++ b/IGDB/Models/User.cs
@@ -1,7 +1,7 @@
 namespace IGDB.Models
 {
-  public class User
+  public class User : IIdentifier
   {
-    public int? Id { get; set; }
+    public long? Id { get; set; }
   }
 }

--- a/IGDB/Models/Website.cs
+++ b/IGDB/Models/Website.cs
@@ -1,10 +1,10 @@
 namespace IGDB.Models
 {
-  public class Website
+  public class Website : IIdentifier
   {
     public WebsiteCategory Category { get; set; }
     public IdentityOrValue<Game> Game { get; set; }
-    public int? Id { get; set; }
+    public long? Id { get; set; }
     public bool? Trusted { get; set; }
     public string Url { get; set; }
   }


### PR DESCRIPTION
BREAKING CHANGE:
- feat: Switch `int` to `long` since IGDB identifiers are int64
- fix: Move `PlatformLogo` and `CompanyLogo` to `IGDB.Models` namespace

Other changes:
- feat: Add `IIdentifier` interface so it's easier to narrow types