### PR TITLE
Companies unix timestamp on start_date under 62135596800 causing exceptions

### DIFF
--- a/IGDB/Serialization/UnixTimestampConverter.cs
+++ b/IGDB/Serialization/UnixTimestampConverter.cs
@@ -21,9 +21,9 @@ namespace IGDB
         {
           var rawValue = reader.Value.ToString();
           long parsedUnixTimestamp;
-          if (long.TryParse(rawValue, out parsedUnixTimestamp))
+          if (long.TryParse(rawValue, out parsedUnixTimestamp) && parsedUnixTimestamp >= -62135596800 && parsedUnixTimestamp <= 253402300799)
           {
-            return DateTimeOffset.FromUnixTimeSeconds(parsedUnixTimestamp);
+              return DateTimeOffset.FromUnixTimeSeconds(parsedUnixTimestamp);
           }
         }
       }


### PR DESCRIPTION
Some of the Companies entries have a unix timestamp on start_date under 62135596800 causing exceptions.

Feel free to use my pull request or fix it yourself if you have a better solution :) Just wanted to bring it to your attention.