### PR TITLE
Add a method to run a count of a query

### DIFF
--- a/IGDB.Tests/Games.cs
+++ b/IGDB.Tests/Games.cs
@@ -97,5 +97,14 @@ namespace IGDB.Tests
       Assert.NotNull(game.CreatedAt);
       Assert.True(game.CreatedAt.Value.Year > 1970);
     }
+    
+    [Fact]
+    public async Task ShouldReturnGameCount()
+    {
+      var gameCount = await _api.CountAsync(IGDBClient.Endpoints.Games, "where id = 4;");
+      
+      Assert.NotNull(gameCount);
+      Assert.Equal(1, gameCount.Count);
+    }
   }
 }

--- a/IGDB/Models/CountResponse.cs
+++ b/IGDB/Models/CountResponse.cs
@@ -1,0 +1,7 @@
+namespace IGDB.Models
+{
+    public class CountResponse
+    {
+        public int Count { get; set; }
+    }
+}


### PR DESCRIPTION
This PR aims to implement a simple method that counts the query items instead of returning them, it is very useful when using pagination.