### PR TITLE
fix: typo in Game Category Episode

### DIFF
--- a/IGDB/Models/Game.cs
+++ b/IGDB/Models/Game.cs
@@ -114,7 +114,7 @@ namespace IGDB.Models
     Bundle = 3,
     StandaloneExpansion = 4,
     Mod = 5,
-    Epuisode = 6,
+    Episode = 6,
     Season = 7,
     Remake = 8,
     Remaster = 9,


### PR DESCRIPTION
Fixed a small typo in Game.cs Category - Epuisode -> Episode