### PR TITLE
May 2024: Remove deprecated APIs for August 2024 update

### DIFF
--- a/IGDB/Models/Collection.cs
+++ b/IGDB/Models/Collection.cs
@@ -9,6 +9,7 @@ namespace IGDB.Models
     public IdentitiesOrValues<CollectionRelation> AsParentRelations { get; set; }
     public string Checksum { get; set; }
     public DateTimeOffset? CreatedAt { get; set; }
+    public IdentitiesOrValues<Game> Games { get; set; }
     public long? Id { get; set; }
     public string Name { get; set; }
     public string Slug { get; set; }

--- a/IGDB/Models/Collection.cs
+++ b/IGDB/Models/Collection.cs
@@ -9,7 +9,6 @@ namespace IGDB.Models
     public IdentitiesOrValues<CollectionRelation> AsParentRelations { get; set; }
     public string Checksum { get; set; }
     public DateTimeOffset? CreatedAt { get; set; }
-    public IdentitiesOrValues<Game> Games { get; set; }
     public long? Id { get; set; }
     public string Name { get; set; }
     public string Slug { get; set; }

--- a/IGDB/Models/Game.cs
+++ b/IGDB/Models/Game.cs
@@ -37,8 +37,6 @@ namespace IGDB.Models
 
     public DateTimeOffset? FirstReleaseDate { get; set; }
 
-    public int? Follows { get; set; }
-
     public IdentitiesOrValues<Game> Forks { get; set; }
 
     public IdentityOrValue<Franchise> Franchise { get; set; }

--- a/IGDB/Models/Game.cs
+++ b/IGDB/Models/Game.cs
@@ -21,8 +21,6 @@ namespace IGDB.Models
 
     public string Checksum { get; set; }
 
-    public IdentityOrValue<Collection> Collection { get; set; }
-
     public IdentitiesOrValues<Collection> Collections { get; set; }
 
     public IdentityOrValue<Cover> Cover { get; set; }

--- a/IGDB/Models/Platform.cs
+++ b/IGDB/Models/Platform.cs
@@ -6,7 +6,7 @@ namespace IGDB.Models
   {
     public string Abbreviation { get; set; }
     public string AlternativeName { get; set; }
-    public PlatformCategory Category { get; set; }
+    public PlatformCategory? Category { get; set; }
     public string Checksum { get; set; }
     public DateTimeOffset? CreatedAt { get; set; }
     public int? Generation { get; set; }


### PR DESCRIPTION
Fixes #32 

> As part of our migration from a 1:many to a many:many relationship between games and series (collections), we have migrated the data that used to be in the old collection field into the new collections field in the games endpoint.  From collections, this can be found through the existing games filed. For the next 6 months (until August 2024) we will serve the data in both locations, then we will **deprecate the collection field in the games endpoint**

> [Discord:](https://discord.com/channels/114736716505546761/548536667884224578/1207258466805358592) Furthermore, unrelated with the collections above, the field **follows in the Game object** is now deprecated and will be going away in future relapses. The main reason is that those data are not maintained anymore and would not produce accurate insights.

# BREAKING CHANGES

- Remove `Game.Collection` property
- Remove `Game.Follows` property
- Change `Platform.Category` to a nullable (e.g. Steam VR)

## Notes

- Confirmed that games will be available on `Collection.Games` field, so undid removal