### PR TITLE
June 2024: Performance and API updates

### DIFF
--- a/IGDB/IGDBApi.cs
+++ b/IGDB/IGDBApi.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 using IGDB.Models;
+using IGDB.Serialization;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using RestEase;

--- a/IGDB/Identity.cs
+++ b/IGDB/Identity.cs
@@ -49,5 +49,10 @@ namespace IGDB
       var list = values.Select(value => (T)value).ToArray();
       Values = list;
     }
+
+    public IdentitiesOrValues(T[] values)
+    {
+      Values = values;
+    }
   }
 }

--- a/IGDB/Models/ExternalGame.cs
+++ b/IGDB/Models/ExternalGame.cs
@@ -12,7 +12,7 @@ namespace IGDB.Models
     public IdentityOrValue<Game> Game { get; set; }
     public long? Id { get; set; }
 
-    public ExternalGameMedia Media { get; set; }
+    public ExternalGameMedia? Media { get; set; }
 
     public string Name { get; set; }
 

--- a/IGDB/Serialization/IdentityConverter.cs
+++ b/IGDB/Serialization/IdentityConverter.cs
@@ -97,11 +97,11 @@ namespace IGDB
     }
 
     public static bool IsIdentityOrValue(Type givenType) {
-      return givenType.Name.Contains("IdentityOrValue`");
+      return givenType.Name.Contains(typeof(IdentityOrValue<>).Name);
     }
 
     public static bool IsIdentitiesOrValues(Type givenType) {
-      return givenType.Name.Contains("IdentitiesOrValues`");
+      return givenType.Name.Contains(typeof(IdentitiesOrValues<>).Name);
     }
   }
 

--- a/IGDB/Serialization/IdentityConverter.cs
+++ b/IGDB/Serialization/IdentityConverter.cs
@@ -5,7 +5,7 @@ using System.Reflection;
 using Newtonsoft.Json;
 using static IGDB.Serialization.LambdaActivator;
 
-namespace IGDB
+namespace IGDB.Serialization
 {
   public class IdentityConverter : JsonConverter
   {
@@ -137,7 +137,7 @@ namespace IGDB
       return activator;
     }
 
-    private static ObjectActivator GetValuesActivator(Type objectType)
+    public static ObjectActivator GetValuesActivator(Type objectType)
     {
       if (valuesActivators.ContainsKey(objectType))
       {
@@ -150,7 +150,7 @@ namespace IGDB
       return activator;
     }
 
-    private static ObjectActivator GetIdentityActivator(Type objectType)
+    public static ObjectActivator GetIdentityActivator(Type objectType)
     {
       if (identityActivators.ContainsKey(objectType))
       {
@@ -163,7 +163,7 @@ namespace IGDB
       return activator;
     }
 
-    private static ObjectActivator GetValueActivator(Type objectType)
+    public static ObjectActivator GetValueActivator(Type objectType)
     {
       if (valueActivators.ContainsKey(objectType))
       {

--- a/IGDB/Serialization/IdentityConverter.cs
+++ b/IGDB/Serialization/IdentityConverter.cs
@@ -96,12 +96,15 @@ namespace IGDB
       }
     }
 
+    private static readonly string IdentitiesOrValuesName = typeof(IdentitiesOrValues<>).Name;
+    private static readonly string IdentityOrValueName = typeof(IdentityOrValue<>).Name;
+    
     public static bool IsIdentityOrValue(Type givenType) {
-      return givenType.Name.Contains(typeof(IdentityOrValue<>).Name);
+      return givenType.Name.Contains(IdentityOrValueName);
     }
 
     public static bool IsIdentitiesOrValues(Type givenType) {
-      return givenType.Name.Contains(typeof(IdentitiesOrValues<>).Name);
+      return givenType.Name.Contains(IdentitiesOrValuesName);
     }
   }
 

--- a/IGDB/Serialization/IdentityConverter.cs
+++ b/IGDB/Serialization/IdentityConverter.cs
@@ -10,8 +10,7 @@ namespace IGDB
   {
     public override bool CanConvert(Type objectType)
     {
-      return IsAssignableToGenericType(objectType, typeof(IdentityOrValue<>)) ||
-      IsAssignableToGenericType(objectType, typeof(IdentitiesOrValues<>));
+      return IsIdentityOrValue(objectType) || IsIdentitiesOrValues(objectType);
     }
 
     public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
@@ -24,7 +23,7 @@ namespace IGDB
       var expandedType = objectType.GetGenericArguments()[0];
       var value = reader.Value;
 
-      if (IsAssignableToGenericType(objectType, typeof(IdentitiesOrValues<>)))
+      if (IsIdentitiesOrValues(objectType))
       {
         if (reader.TokenType != JsonToken.StartArray)
         {
@@ -59,7 +58,7 @@ namespace IGDB
         var ctor = objectType.GetConstructor(new[] { typeof(object[]) });
         return ctor.Invoke(new[] { convertedValues });
       }
-      else if (IsAssignableToGenericType(objectType, typeof(IdentityOrValue<>)))
+      else if (IsIdentityOrValue(objectType))
       {
         if (reader.TokenType == JsonToken.StartObject)
         {
@@ -82,11 +81,11 @@ namespace IGDB
       {
         dynamic identity = value;
 
-        if (IsAssignableToGenericType(value.GetType(), typeof(IdentitiesOrValues<>)))
+        if (IsIdentitiesOrValues(value.GetType()))
         {
           serializer.Serialize(writer, identity.Ids ?? identity.Values ?? null);
         }
-        else if (IsAssignableToGenericType(value.GetType(), typeof(IdentityOrValue<>)))
+        else if (IsIdentityOrValue(value.GetType()))
         {
           serializer.Serialize(writer, identity.Id ?? identity.Value ?? null);
         }
@@ -97,23 +96,12 @@ namespace IGDB
       }
     }
 
-    public static bool IsAssignableToGenericType(Type givenType, Type genericType)
-    {
-      var interfaceTypes = givenType.GetInterfaces();
+    public static bool IsIdentityOrValue(Type givenType) {
+      return givenType.Name.Contains("IdentityOrValue`");
+    }
 
-      foreach (var it in interfaceTypes)
-      {
-        if (it.IsGenericType && it.GetGenericTypeDefinition() == genericType)
-          return true;
-      }
-
-      if (givenType.IsGenericType && givenType.GetGenericTypeDefinition() == genericType)
-        return true;
-
-      Type baseType = givenType.BaseType;
-      if (baseType == null) return false;
-
-      return IsAssignableToGenericType(baseType, genericType);
+    public static bool IsIdentitiesOrValues(Type givenType) {
+      return givenType.Name.Contains("IdentitiesOrValues`");
     }
   }
 

--- a/IGDB/Serialization/IdentityConverter.cs
+++ b/IGDB/Serialization/IdentityConverter.cs
@@ -1,8 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
+using static IGDB.Serialization.LambdaActivator;
 
 namespace IGDB
 {
@@ -47,28 +48,33 @@ namespace IGDB
           }
         }
 
+        var valuesActivator = GetValuesActivator(objectType);
+        var identitiesActivator = GetIdentitiesActivator(objectType);
+
         // If any are objects, it means the IDs should be ignored
         if (values.All(v => v.GetType().IsAssignableFrom(typeof(long))))
         {
-          return Activator.CreateInstance(objectType, values.Cast<long>().ToArray());
+          return identitiesActivator(values.Cast<long>().ToArray());
         }
 
         var objects = values.Where(v => !v.GetType().IsAssignableFrom(typeof(long)));
         var convertedValues = objects.ToArray();
-        var ctor = objectType.GetConstructor(new[] { typeof(object[]) });
-        return ctor.Invoke(new[] { convertedValues });
+        return valuesActivator(new[] { convertedValues });
       }
       else if (IsIdentityOrValue(objectType))
       {
+        var identityActivator = GetIdentityActivator(objectType);
+        var valueActivator = GetValueActivator(objectType);
+
         if (reader.TokenType == JsonToken.StartObject)
         {
           // objects
-          return Activator.CreateInstance(objectType, serializer.Deserialize(reader, expandedType));
+          return valueActivator(serializer.Deserialize(reader, expandedType));
         }
         else if (reader.TokenType == JsonToken.Integer)
         {
           // int ids
-          return Activator.CreateInstance(objectType, (long)reader.Value);
+          return identityActivator((long)reader.Value);
         }
       }
 
@@ -98,15 +104,79 @@ namespace IGDB
 
     private static readonly string IdentitiesOrValuesName = typeof(IdentitiesOrValues<>).Name;
     private static readonly string IdentityOrValueName = typeof(IdentityOrValue<>).Name;
-    
-    public static bool IsIdentityOrValue(Type givenType) {
+
+    public static bool IsIdentityOrValue(Type givenType)
+    {
       return givenType.Name.Contains(IdentityOrValueName);
     }
 
-    public static bool IsIdentitiesOrValues(Type givenType) {
+    public static bool IsIdentitiesOrValues(Type givenType)
+    {
       return givenType.Name.Contains(IdentitiesOrValuesName);
     }
+
+    private static readonly IDictionary<Type, ObjectActivator> identitiesActivators
+    = new Dictionary<Type, ObjectActivator>();
+    private static readonly IDictionary<Type, ObjectActivator> valuesActivators
+    = new Dictionary<Type, ObjectActivator>();
+    private static readonly IDictionary<Type, ObjectActivator> identityActivators
+        = new Dictionary<Type, ObjectActivator>();
+    private static readonly IDictionary<Type, ObjectActivator> valueActivators
+        = new Dictionary<Type, ObjectActivator>();
+
+    private static ObjectActivator GetIdentitiesActivator(Type objectType)
+    {
+      if (identitiesActivators.ContainsKey(objectType))
+      {
+        return identitiesActivators[objectType];
+      }
+
+      ConstructorInfo ctor = objectType.GetConstructors().Skip(1).First();
+      var activator = GetActivator(ctor);
+      identitiesActivators[objectType] = activator;
+      return activator;
+    }
+
+    private static ObjectActivator GetValuesActivator(Type objectType)
+    {
+      if (valuesActivators.ContainsKey(objectType))
+      {
+        return valuesActivators[objectType];
+      }
+
+      ConstructorInfo ctor = objectType.GetConstructors().Skip(2).First();
+      var activator = GetActivator(ctor);
+      valuesActivators[objectType] = activator;
+      return activator;
+    }
+
+    private static ObjectActivator GetIdentityActivator(Type objectType)
+    {
+      if (identityActivators.ContainsKey(objectType))
+      {
+        return identityActivators[objectType];
+      }
+
+      ConstructorInfo ctor = objectType.GetConstructors().Skip(1).First();
+      var activator = GetActivator(ctor);
+      identityActivators[objectType] = activator;
+      return activator;
+    }
+
+    private static ObjectActivator GetValueActivator(Type objectType)
+    {
+      if (valueActivators.ContainsKey(objectType))
+      {
+        return valueActivators[objectType];
+      }
+
+      ConstructorInfo ctor = objectType.GetConstructors().Skip(2).First();
+      var activator = GetActivator(ctor);
+      valueActivators[objectType] = activator;
+      return activator;
+    }
   }
+
 
 
 }

--- a/IGDB/Serialization/IdentityConverter.cs
+++ b/IGDB/Serialization/IdentityConverter.cs
@@ -124,7 +124,7 @@ namespace IGDB.Serialization
     private static readonly IDictionary<Type, ObjectActivator> valueActivators
         = new Dictionary<Type, ObjectActivator>();
 
-    private static ObjectActivator GetIdentitiesActivator(Type objectType)
+    public static ObjectActivator GetIdentitiesActivator(Type objectType)
     {
       if (identitiesActivators.ContainsKey(objectType))
       {

--- a/IGDB/Serialization/LamdaActivator.cs
+++ b/IGDB/Serialization/LamdaActivator.cs
@@ -4,13 +4,13 @@ using System.Reflection;
 
 namespace IGDB.Serialization
 {
+  public delegate object ObjectActivator(params object[] args);
+
   /// <summary>
   /// See: https://rogerjohansson.blog/2008/02/28/linq-expressions-creating-objects/
   /// </summary>
-  public static class LambdaActivator
+  internal static class LambdaActivator
   {
-    public delegate object ObjectActivator(params object[] args);
-
     public static ObjectActivator GetActivator(ConstructorInfo ctor)
     {
       ParameterInfo[] paramsInfo = ctor.GetParameters();

--- a/IGDB/Serialization/LamdaActivator.cs
+++ b/IGDB/Serialization/LamdaActivator.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace IGDB.Serialization
+{
+  /// <summary>
+  /// See: https://rogerjohansson.blog/2008/02/28/linq-expressions-creating-objects/
+  /// </summary>
+  public static class LambdaActivator
+  {
+    public delegate object ObjectActivator(params object[] args);
+
+    public static ObjectActivator GetActivator(ConstructorInfo ctor)
+    {
+      ParameterInfo[] paramsInfo = ctor.GetParameters();
+
+      ParameterExpression param =
+          Expression.Parameter(typeof(object[]), "args");
+
+      Expression[] argsExp =
+          new Expression[paramsInfo.Length];
+
+      for (int i = 0; i < paramsInfo.Length; i++)
+      {
+        Expression index = Expression.Constant(i);
+        Type paramType = paramsInfo[i].ParameterType;
+
+        Expression paramAccessorExp =
+            Expression.ArrayIndex(param, index);
+
+        Expression paramCastExp =
+            Expression.Convert(paramAccessorExp, paramType);
+
+        argsExp[i] = paramCastExp;
+      }
+
+      NewExpression newExp = Expression.New(ctor, argsExp);
+
+      LambdaExpression lambda =
+          Expression.Lambda(typeof(ObjectActivator), newExp, param);
+
+      ObjectActivator compiled = (ObjectActivator)lambda.Compile();
+      return compiled;
+    }
+  }
+}

--- a/IGDB/Serialization/UnixTimestampConverter.cs
+++ b/IGDB/Serialization/UnixTimestampConverter.cs
@@ -2,7 +2,7 @@ using System;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
-namespace IGDB
+namespace IGDB.Serialization
 {
   public class UnixTimestampConverter : JsonConverter
   {


### PR DESCRIPTION
## BREAKING CHANGES

- **Fix:** Mark `ExternalGame.Media` enum property as nullable
- Removed public static `IdentityConverter.IsAssignableToGenericType` helper and replaced with `IsIdentityOrValue` and `IsIdentitiesOrValues` static helpers

## Changes

- **Performance:** Refactored `IdentityConverter` to speed up deserialization using a [compiled Lamda activator](https://rogerjohansson.blog/2008/02/28/linq-expressions-creating-objects/) and avoiding excessive type checks
  - _Note_: I may look into integrating this into https://github.com/JaCraig/FastActivator
- Expose `IdentityConverter.GetIdentitiesActivator` for constructing `IdentitiesOrValues<>` with `long[]`
- Expose `IdentityConverter.GetValuesActivator` for constructing `IdentitiesOrValues<>` with `object[]`
- Expose `IdentityConverter.GetIdentityActivator` for constructing `IdentityOrValue<>` with `long`
- Expose `IdentityConverter.GetValueActivator` for constructing `IdentityOrValue<>` with `object`

## Notes

When dealing with IGDB Data Dumps and using CsvHelper, I needed to create a type converter to construct `IdentityOrValue<>` and `IdentitiesOrValues<>` instances. With 280,000 games (and associated data!), that's a lot of instances. In my CPU profile, `Activator.CreateInstance` was a bottleneck so I went exploring and found Lambda activation instead.

Now in CsvHelper, I have defined a `ITypeConverter` like this:

```c#
public class IgdbIdentityArrayConverter : ITypeConverter
{
    public object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData)
    {
        var objectType = memberMapData.Member.MemberType();

        if (!IdentityConverter.IsIdentitiesOrValues(objectType))
        {
            return null;
        }

        var activator = IdentityConverter.GetValuesActivator(objectType);

        if (string.IsNullOrEmpty(text))
        {
            return activator(new long[0]);
        }

        var values = text.Trim('{', '}').Split(',');

        var convertedValues = values.Select(v => long.Parse(v)).ToArray();

        return activator(convertedValues);
    }

    public string ConvertToString(object value, IWriterRow row, MemberMapData memberMapData)
    {
        throw new NotImplementedException("Converting IdentitiesOrValues to string is not implemented");
    }
}

public class IgdbIdentityConverter : ITypeConverter
{
    public object ConvertFromString(string text, IReaderRow row, MemberMapData memberMapData)
    {
        var objectType = memberMapData.Member.MemberType();

        if (!IdentityConverter.IsIdentityOrValue(objectType))
        {
            return null;
        }

        if (long.TryParse(text, out long id))
        {
            var createId = IdentityConverter.GetIdentityActivator(objectType);
            return createId(id);
        }

        return null;
    }

    public string ConvertToString(object value, IWriterRow row, MemberMapData memberMapData)
    {
        throw new NotImplementedException("Converting IdentityOrValue to string is not implemented");
    }
}
```

And that speeds up CSV parsing _significantly._