### PR TITLE
Add QueryWithResponse API

### DIFF
--- a/IGDB.Tests/Games.cs
+++ b/IGDB.Tests/Games.cs
@@ -28,6 +28,25 @@ namespace IGDB.Tests
     }
 
     [Fact]
+    public async Task ShouldReturnResponseWithHeaders()
+    {
+      var games = await _api.QueryWithResponseAsync<Game>(IGDBClient.Endpoints.Games);
+
+      Assert.NotNull(games);
+      Assert.True(games.GetContent().Length == 10);
+
+      var rawCount = games.ResponseMessage.Headers.GetValues("x-count").First();
+
+      Assert.NotNull(rawCount);
+      Assert.True(int.Parse(rawCount) > 0);
+
+      var queryCount = games.GetQueryCount();
+
+      Assert.NotNull(queryCount);
+      Assert.True(queryCount > 0);
+    }
+
+    [Fact]
     public async Task ShouldReturnResponseWithSingleGame()
     {
       var games = await _api.QueryAsync<Game>(IGDBClient.Endpoints.Games, "fields id,name,genres; where id = 4;");
@@ -159,12 +178,12 @@ namespace IGDB.Tests
 
       Assert.NotEmpty(game.Dlcs.Ids);
     }
-    
+
     [Fact]
     public async Task ShouldReturnGameCount()
     {
       var gameCount = await _api.CountAsync(IGDBClient.Endpoints.Games, "where id = 4;");
-      
+
       Assert.NotNull(gameCount);
       Assert.Equal(1, gameCount.Count);
     }

--- a/IGDB/ResponseExtensions.cs
+++ b/IGDB/ResponseExtensions.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Linq;
+using System.Net.Http;
+using RestEase;
+
+namespace IGDB
+{
+  public static class ResponseExtensions
+  {
+    private const string CountHeader = "x-count";
+
+    /// <summary>
+    /// The value of the X-Count header for IGDB query endpoints, if it exists.
+    /// </summary>
+    public static int? GetQueryCount<T>(this Response<T> response)
+    {
+      return int.TryParse(response.ResponseMessage.Headers.GetValues(CountHeader).First(), out var count) ? count : (int?)null;
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -69,6 +69,16 @@ game.Cover.Value.Width; // 756
 game.Cover.Value.Height;
 ```
 
+### Handling Query Counts
+
+You can use the `QueryWithResponse` API to return the raw `HttpResponseMessage` along with the deserialized response through `GetContent()`.
+
+There is an extension method available that will retrieve the `X-Count` header returned by IGDB on query endpoints. This avoids having to issue two requests to get the total results for a query. You also have full access to any headers through the `ResponseMessage` property.
+
+**See IGDB.Tests/Games.cs#ShouldReturnResponseWithHeaders** for an example test that covers this feature. You can also read more about the `Response<T>` [support in RestEase](https://github.com/canton7/RestEase?tab=readme-ov-file#return-types).
+
+Alternatively, you can also use the `CountAsync()` API to just retrieve the count for a query.
+
 ### Custom Token Management
 
 By default this client will request a OAuth bearer token on your behalf that is valid for 60 days and will store it statically **in memory**. If an invalid token is used and a 401 response is received, it will automatically acquire a new token and retry the request. See `TokenManagement.cs` for the default implementation.


### PR DESCRIPTION
Closes #26 

## Changes

- Add `QueryWithResponse<T>` API method which exposes the underlying `HttpResponseMessage` to access response headers alongside the deserialized response
- Add `ResponseExtensions.GetQueryCount()` method to parse and return the value of `X-Count` header returned by IGDB on query endpoints