### PR TITLE
chore(tests): fix rate limiting issue

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore
       - name: Test
-        run: dotnet test --verbosity normal
+        run: dotnet test --verbosity normal --filter "Category!=LocalOnly"
         env:
           IGDB_CLIENT_ID: ${{ secrets.IGDB_CLIENT_ID }}
           IGDB_CLIENT_SECRET: ${{ secrets.IGDB_CLIENT_SECRET }}

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Restore dependencies
         run: dotnet restore
       - name: Test
-        run: dotnet test --verbosity normal --filter "Category!=LocalOnly"
+        run: dotnet test --verbosity normal --filter "Category!=SkipCi"
         env:
           IGDB_CLIENT_ID: ${{ secrets.IGDB_CLIENT_ID }}
           IGDB_CLIENT_SECRET: ${{ secrets.IGDB_CLIENT_SECRET }}

--- a/IGDB.Tests/AssemblyInfo.cs
+++ b/IGDB.Tests/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using Xunit;
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/IGDB.Tests/Dumps.cs
+++ b/IGDB.Tests/Dumps.cs
@@ -7,6 +7,7 @@ using Xunit;
 
 namespace IGDB.Tests
 {
+  [Collection("/dumps")]
   public class Dumps
   {
     IGDBClient _api;

--- a/IGDB.Tests/Dumps.cs
+++ b/IGDB.Tests/Dumps.cs
@@ -21,6 +21,7 @@ namespace IGDB.Tests
     }
 
     [Fact]
+    [Trait("Category", "SkipCi")]
     public async Task ShouldReturnDumpsList()
     {
       var dumps = await _api.GetDataDumpsAsync();
@@ -30,6 +31,7 @@ namespace IGDB.Tests
     }
 
     [Fact]
+    [Trait("Category", "SkipCi")]
     public async Task ShouldReturnGamesEndpointDump()
     {
       var gameDump = await _api.GetDataDumpEndpointAsync(IGDBClient.Endpoints.Games);

--- a/IGDB.Tests/Dumps.cs
+++ b/IGDB.Tests/Dumps.cs
@@ -14,7 +14,7 @@ namespace IGDB.Tests
 
     public Dumps()
     {
-      _api = new IGDB.IGDBClient(
+      _api = IGDBClient.CreateWithDefaults(
         Environment.GetEnvironmentVariable("IGDB_CLIENT_ID"),
         Environment.GetEnvironmentVariable("IGDB_CLIENT_SECRET")
       );

--- a/IGDB.Tests/GameTimeToBeats.cs
+++ b/IGDB.Tests/GameTimeToBeats.cs
@@ -4,6 +4,7 @@ using Xunit;
 
 namespace IGDB.Tests
 {
+  [Collection("/game_time_to_beats")]
   public class GameTimeToBeats
   {
     IGDBClient _api;

--- a/IGDB.Tests/GameTimeToBeats.cs
+++ b/IGDB.Tests/GameTimeToBeats.cs
@@ -11,7 +11,7 @@ namespace IGDB.Tests
 
     public GameTimeToBeats()
     {
-      _api = new IGDB.IGDBClient(
+      _api = IGDBClient.CreateWithDefaults(
         Environment.GetEnvironmentVariable("IGDB_CLIENT_ID"),
         Environment.GetEnvironmentVariable("IGDB_CLIENT_SECRET")
       );

--- a/IGDB.Tests/Games.cs
+++ b/IGDB.Tests/Games.cs
@@ -13,7 +13,7 @@ namespace IGDB.Tests
 
     public Games()
     {
-      _api = new IGDB.IGDBClient(
+      _api = IGDBClient.CreateWithDefaults(
         Environment.GetEnvironmentVariable("IGDB_CLIENT_ID"),
         Environment.GetEnvironmentVariable("IGDB_CLIENT_SECRET")
       );

--- a/IGDB.Tests/Games.cs
+++ b/IGDB.Tests/Games.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace IGDB.Tests
 {
+  [Collection("/games")]
   public class Games
   {
     IGDBClient _api;

--- a/IGDB.Tests/IGDB.Tests.csproj
+++ b/IGDB.Tests/IGDB.Tests.csproj
@@ -4,7 +4,6 @@
     <TargetFramework>net9.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
-    <DefineConstants>$(DefineConstants);IGDB_TESTS</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/IGDB.Tests/Platforms.cs
+++ b/IGDB.Tests/Platforms.cs
@@ -6,6 +6,7 @@ using Xunit;
 
 namespace IGDB.Tests
 {
+  [Collection("/platforms")]
   public class Platforms
   {
     IGDBClient _api;

--- a/IGDB.Tests/Platforms.cs
+++ b/IGDB.Tests/Platforms.cs
@@ -13,7 +13,7 @@ namespace IGDB.Tests
 
     public Platforms()
     {
-      _api = new IGDB.IGDBClient(
+      _api = IGDBClient.CreateWithDefaults(
         Environment.GetEnvironmentVariable("IGDB_CLIENT_ID"),
         Environment.GetEnvironmentVariable("IGDB_CLIENT_SECRET")
       );

--- a/IGDB.Tests/PopScore.cs
+++ b/IGDB.Tests/PopScore.cs
@@ -6,53 +6,54 @@ using Xunit;
 
 namespace IGDB.Tests
 {
+  [Collection("/popularity_types")]
 	public class PopScore
-	{
-		IGDBClient _api;
+  {
+    IGDBClient _api;
 
-		public PopScore()
-		{
-			_api = new IGDB.IGDBClient(
-			  Environment.GetEnvironmentVariable("IGDB_CLIENT_ID"),
-			  Environment.GetEnvironmentVariable("IGDB_CLIENT_SECRET")
-			);
-		}
+    public PopScore()
+    {
+      _api = new IGDB.IGDBClient(
+        Environment.GetEnvironmentVariable("IGDB_CLIENT_ID"),
+        Environment.GetEnvironmentVariable("IGDB_CLIENT_SECRET")
+      );
+    }
 
-		[Fact]
-		public async Task ShouldReturnAllPopularityTypes()
-		{
-			var popularityTypes = await _api.QueryAsync<PopularityType>(IGDBClient.Endpoints.PopularityTypes, "fields *;");
+    [Fact]
+    public async Task ShouldReturnAllPopularityTypes()
+    {
+      var popularityTypes = await _api.QueryAsync<PopularityType>(IGDBClient.Endpoints.PopularityTypes, "fields *;");
 
-			Assert.NotNull(popularityTypes);
-			foreach (var popularityType in popularityTypes)
-			{
-				Assert.NotNull(popularityType.Checksum);
-				Assert.NotNull(popularityType.CreatedAt);
-				Assert.NotNull(popularityType.Name);
-				Assert.NotNull(popularityType.ExternalPopularitySource.Id);
-				Assert.NotNull(popularityType.UpdatedAt);
-			}
-		}
+      Assert.NotNull(popularityTypes);
+      foreach (var popularityType in popularityTypes)
+      {
+        Assert.NotNull(popularityType.Checksum);
+        Assert.NotNull(popularityType.CreatedAt);
+        Assert.NotNull(popularityType.Name);
+        Assert.NotNull(popularityType.ExternalPopularitySource.Id);
+        Assert.NotNull(popularityType.UpdatedAt);
+      }
+    }
 
-		[Fact]
-		public async Task ShouldReturnLimitedPopularityPrimitives()
-		{
-			var popularityPrimitives = await _api.QueryAsync<PopularityPrimitive>(
-				IGDBClient.Endpoints.PopularityPrimitives,
-				"fields *; limit 10;");
+    [Fact]
+    public async Task ShouldReturnLimitedPopularityPrimitives()
+    {
+      var popularityPrimitives = await _api.QueryAsync<PopularityPrimitive>(
+        IGDBClient.Endpoints.PopularityPrimitives,
+        "fields *; limit 10;");
 
-			Assert.NotNull(popularityPrimitives);
-			Assert.True(popularityPrimitives.Length == 10);
+      Assert.NotNull(popularityPrimitives);
+      Assert.True(popularityPrimitives.Length == 10);
 
-			foreach (var popularityPrimitive in popularityPrimitives)
-			{
-				Assert.NotNull(popularityPrimitive.CalculatedAt);
-				Assert.NotNull(popularityPrimitive.CreatedAt);
-				Assert.NotNull(popularityPrimitive.ExternalPopularitySource.Id);
-				Assert.NotNull(popularityPrimitive.PopularityType);
-				Assert.NotNull(popularityPrimitive.UpdatedAt);
-				Assert.NotNull(popularityPrimitive.Value);
-			}
-		}
-	}
+      foreach (var popularityPrimitive in popularityPrimitives)
+      {
+        Assert.NotNull(popularityPrimitive.CalculatedAt);
+        Assert.NotNull(popularityPrimitive.CreatedAt);
+        Assert.NotNull(popularityPrimitive.ExternalPopularitySource.Id);
+        Assert.NotNull(popularityPrimitive.PopularityType);
+        Assert.NotNull(popularityPrimitive.UpdatedAt);
+        Assert.NotNull(popularityPrimitive.Value);
+      }
+    }
+  }
 }

--- a/IGDB.Tests/PopScore.cs
+++ b/IGDB.Tests/PopScore.cs
@@ -13,7 +13,7 @@ namespace IGDB.Tests
 
     public PopScore()
     {
-      _api = new IGDB.IGDBClient(
+      _api = IGDBClient.CreateWithDefaults(
         Environment.GetEnvironmentVariable("IGDB_CLIENT_ID"),
         Environment.GetEnvironmentVariable("IGDB_CLIENT_SECRET")
       );

--- a/IGDB.Tests/TokenHandling.cs
+++ b/IGDB.Tests/TokenHandling.cs
@@ -18,7 +18,8 @@ namespace IGDB.Tests
       var invalidTokenClient = new IGDB.IGDBClient(
         Environment.GetEnvironmentVariable("IGDB_CLIENT_ID"),
         Environment.GetEnvironmentVariable("IGDB_CLIENT_SECRET"),
-        tokenStore
+        tokenStore,
+        ApiPolicy.DefaultApiPolicy
       );
 
       var games = await invalidTokenClient.QueryAsync<Game>("games");
@@ -34,7 +35,8 @@ namespace IGDB.Tests
       var client = new IGDB.IGDBClient(
         Environment.GetEnvironmentVariable("IGDB_CLIENT_ID"),
         Environment.GetEnvironmentVariable("IGDB_CLIENT_SECRET"),
-        tokenStore
+        tokenStore,
+        ApiPolicy.DefaultApiPolicy
       );
 
       await client.QueryAsync<Game>("games");
@@ -51,7 +53,8 @@ namespace IGDB.Tests
       var client = new IGDB.IGDBClient(
         Environment.GetEnvironmentVariable("IGDB_CLIENT_ID"),
         Environment.GetEnvironmentVariable("IGDB_CLIENT_SECRET"),
-        tokenStore
+        tokenStore,
+        ApiPolicy.DefaultApiPolicy
       );
 
       await client.QueryAsync<Game>("games");

--- a/IGDB/ApiPolicy.cs
+++ b/IGDB/ApiPolicy.cs
@@ -1,0 +1,50 @@
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+using Polly;
+using Polly.Bulkhead;
+using Polly.RateLimit;
+
+namespace IGDB
+{
+  public static class ApiPolicy
+  {
+    private static readonly Random _jitter = new Random();
+    private const int MaxRetries = 3;
+    private const double RetryDelayBaseSeconds = 0.5;
+    private const int MaxParallelization = 6;
+    private const int MaxQueuingActions = 32;
+    private const int MaxRateLimit = 4;
+    private const int JitterMs = 500;
+    private static readonly TimeSpan RateLimitPeriod = TimeSpan.FromMilliseconds(900);
+
+    /// <summary>
+    /// Default API policy for handling HTTP requests to IGDB.
+    /// 
+    /// This policy includes:
+    /// - Retry logic for rate limit and bulkhead exceptions with exponential backoff and jitter.
+    /// - Bulkhead isolation to limit the number of concurrent requests.
+    /// - Rate limiting to control the request rate.
+    /// 
+    /// The retry logic will attempt to retry up to 3 times with an exponential backoff strategy,
+    /// adding a random jitter of up to ±500ms to avoid thundering herd problems.
+    /// </summary>
+    public static readonly IAsyncPolicy<HttpResponseMessage> DefaultApiPolicy
+        = Policy.WrapAsync(
+          Policy<HttpResponseMessage>.Handle<RateLimitRejectedException>()
+            .Or<BulkheadRejectedException>()
+            .WaitAndRetryAsync(
+              retryCount: MaxRetries,
+              sleepDurationProvider: (retryAttempt) =>
+              {
+                var backOff = TimeSpan.FromSeconds(RetryDelayBaseSeconds * Math.Pow(2, retryAttempt - 1));
+                var jitter = TimeSpan.FromMilliseconds(_jitter.Next(-JitterMs, JitterMs));
+                return backOff + jitter;
+              },
+              onRetry: (_, __, ___) => { }
+            ),
+            Policy.BulkheadAsync<HttpResponseMessage>(maxParallelization: MaxParallelization, maxQueuingActions: MaxQueuingActions),
+            Policy.RateLimitAsync<HttpResponseMessage>(MaxRateLimit, RateLimitPeriod)
+        );
+  }
+}

--- a/IGDB/IGDB.csproj
+++ b/IGDB/IGDB.csproj
@@ -31,6 +31,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.5" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/IGDB/IGDBApi.cs
+++ b/IGDB/IGDBApi.cs
@@ -9,7 +9,6 @@ using Microsoft.Extensions.Http;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Serialization;
 using Polly;
-using Polly.RateLimit;
 using RestEase;
 using RestEase.Implementation;
 
@@ -86,19 +85,6 @@ namespace IGDB
     };
 
     /// <summary>
-    /// Default policy for IGDB API requests. This policy wraps a bulkhead and rate limit policy 
-    /// to ensure that no more than 8 concurrent requests are made, 
-    /// and no more than 4 requests are made every 10 seconds.
-    /// </summary>
-    public static IAsyncPolicy<HttpResponseMessage> DefaultPolicy { get; } 
-        = Policy.WrapAsync(
-            // Bulkhead: no more than 8 concurrent requests, zero queue
-            Policy.BulkheadAsync<HttpResponseMessage>(maxParallelization: 8, maxQueuingActions: 0),
-            // RateLimit: no more than 4 calls per 10s
-            Policy.RateLimitAsync<HttpResponseMessage>(4, TimeSpan.FromSeconds(10))
-        );
-
-    /// <summary>
     /// Create a IGDB API client based on a custom-created RestEase client. Adds required
     /// JSON serializer settings on top of any existing settings. Uses default in-memory access token management.
     /// </summary>
@@ -132,7 +118,7 @@ namespace IGDB
 
       if (policy == null)
       {
-        policy = DefaultPolicy;
+        policy = ApiPolicy.DefaultApiPolicy;
       }
 
       var messageHandler = new PolicyHttpMessageHandler(policy)
@@ -166,10 +152,6 @@ namespace IGDB
       try
       {
         return await _api.QueryAsync<T>(endpoint, query);
-      }
-      catch (RateLimitRejectedException rateLimitEx)
-      {
-        
       }
       catch (ApiException apiEx)
       {
@@ -329,8 +311,8 @@ namespace IGDB
       public const string PlatformVersionReleaseDates = "platform_version_release_dates";
       public const string PlatformWebsites = "platform_websites";
       public const string PlayerPerspectives = "player_perspectives";
-	  public const string PopularityPrimitives = "popularity_primitives";
-	  public const string PopularityTypes = "popularity_types";
+      public const string PopularityPrimitives = "popularity_primitives";
+      public const string PopularityTypes = "popularity_types";
       public const string ReleaseDates = "release_dates";
       public const string ReleaseDateRegions = "release_date_regions";
       public const string Screenshots = "screenshots";

--- a/IGDB/IGDBApi.cs
+++ b/IGDB/IGDBApi.cs
@@ -127,7 +127,7 @@ namespace IGDB
         #if IGDB_TESTS
         
         // Workaround rate limit in an extremely naive way...
-        await Task.Delay(1000 / 2);
+        await Task.Delay(1000 / 3);
 
         #endif
 


### PR DESCRIPTION
Should be able to run tests in GH actions without running into rate limits.

## Changes

- Add new `IGDBClient.CreateWithDefaults` static helper to create an IGDB client configured with all the defaults
- Add default Polly API policy to `IGDB.ApiPolicy` static class and `DefaultApiPolicy` async policy
- Add an overload for passing an `IAsyncPolicy<HttpResponseMessage>` to the client constructor

## Notes

- If the policy is applied by default, it would be a breaking change. **Benefit:** Just works with IGDB API limits out-of-the-box. **Drawback:** Unexpected behavior if someone needs complete control over request timing.
- I could make it optional, so you could still pass the default policy (and tests would always pass it). **Benefit:** Customizable, backwards-compatible. **Drawback:** Doesn't "just work" out-of-the-box, more likely to run into 429 exceptions and then accidentally try to workaround in userland code.
- If I changed it to pass in an HTTP message handler, it could be possible to remove the dependency on Polly from the core library and only do it in tests (but document it so that people can do it on their own) -- **Benefit:** No dependency on Polly and people can implement a handler however they want. **Drawback:** Its not built-in so it won't "just work" out of the box. Same drawback as above.